### PR TITLE
feat: always exclude node_modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ stored in `node_modules`, a negative glob can be used:
 ```js
 const exclude = require('test-exclude')
 const e = exclude({
-  exclude: ['**/!node_modules']
+  exclude: ['!**/node_modules/**']
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ if (exclude({configKey: 'test'}).shouldInstrument('./index.js')) {
 }
 ```
 
+## Including node_modules folder
+
+by default the `node_modules` folder is added to all groups of
+exclude rules. In the rare case that you wish to instrument files
+stored in `node_modules`, a negative glob can be used:
+
+```js
+const exclude = require('test-exclude')
+const e = exclude({
+  exclude: ['**/!node_modules']
+})
+```
+
 ## License
 
 ISC

--- a/index.js
+++ b/index.js
@@ -28,6 +28,17 @@ function TestExclude (opts) {
     this.include = false
   }
 
+  // unless someone explicitly provides !node_modules
+  // always ignore node_modules.
+  if (
+    !this.exclude.filter(function (e) {
+      return /!node_modules/.test(e)
+    }).length &&
+    this.exclude.indexOf('**/node_modules/**') === -1
+  ) {
+    this.exclude.push('**/node_modules/**')
+  }
+
   this.exclude = prepGlobPatterns(
     [].concat(arrify(this.exclude))
   )
@@ -74,8 +85,7 @@ exportFunc.defaultExclude = [
   'test/**',
   'test{,-*}.js',
   '**/*.test.js',
-  '**/__tests__/**',
-  '**/node_modules/**'
+  '**/__tests__/**'
 ]
 
 module.exports = exportFunc

--- a/test/test-exclude.js
+++ b/test/test-exclude.js
@@ -47,9 +47,20 @@ describe('testExclude', function () {
     e.shouldInstrument('src/foo/bar.js').should.equal(true)
   })
 
-  it('does not exclude anything if an empty array passed', function () {
+  it('excludes node_modules folder, even when empty exclude group is provided', function () {
     const e = exclude({
       exclude: []
+    })
+
+    e.shouldInstrument('node_modules/some/module/to/cover.js').should.equal(false)
+    e.shouldInstrument('__tests__/a-test.js').should.equal(true)
+    e.shouldInstrument('src/a.test.js').should.equal(true)
+    e.shouldInstrument('src/foo.js').should.equal(true)
+  })
+
+  it('allows node_modules folder to be included, if !node_modules is explicitly provided', function () {
+    const e = exclude({
+      exclude: ['**/!node_modules']
     })
 
     e.shouldInstrument('node_modules/some/module/to/cover.js').should.equal(true)

--- a/test/test-exclude.js
+++ b/test/test-exclude.js
@@ -60,7 +60,7 @@ describe('testExclude', function () {
 
   it('allows node_modules folder to be included, if !node_modules is explicitly provided', function () {
     const e = exclude({
-      exclude: ['**/!node_modules']
+      exclude: ['!**/node_modules/**']
     })
 
     e.shouldInstrument('node_modules/some/module/to/cover.js').should.equal(true)


### PR DESCRIPTION
The fact that we don't add `node_modules` to the default set of exclude rules, was repeatedly stepping on people's toes. This breaking change always adds `node_modules`.

CC: @JaKXz, @sindresorhus.