### PR TITLE
feat: we now support dot folders

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ function TestExclude (opts) {
 
   if (!this.removeNegatedModuleExclude() && this.exclude.indexOf('**/node_modules/**') === -1) {
     this.exclude.push('**/node_modules/**')
+    this.exclude.push('node_modules/**')
   }
 
   this.exclude = prepGlobPatterns(
@@ -58,7 +59,7 @@ TestExclude.prototype.shouldInstrument = function (filename, relFile) {
   if (/^\.\./.test(path.relative(this.cwd, filename))) return false
 
   relFile = relFile.replace(/^\.[\\\/]/, '') // remove leading './' or '.\'.
-  return (!this.include || micromatch.any(relFile, this.include)) && !micromatch.any(relFile, this.exclude)
+  return (!this.include || micromatch.any(relFile, this.include, {dotfiles: true})) && !micromatch.any(relFile, this.exclude, {dotfiles: true})
 }
 
 TestExclude.prototype.pkgConf = function (key, path) {
@@ -93,7 +94,8 @@ exportFunc.defaultExclude = [
   'test{,-*}.js',
   '**/*.test.js',
   '**/__tests__/**',
-  '**/node_modules/**'
+  '**/node_modules/**',
+  'node_modules/**'
 ]
 
 module.exports = exportFunc

--- a/test/test-exclude.js
+++ b/test/test-exclude.js
@@ -7,6 +7,7 @@ require('chai').should()
 describe('testExclude', function () {
   it('should exclude the node_modules folder by default', function () {
     exclude().shouldInstrument('./banana/node_modules/cat.js').should.equal(false)
+    exclude().shouldInstrument('node_modules/cat.js').should.equal(false)
   })
 
   it('ignores ./', function () {
@@ -47,11 +48,17 @@ describe('testExclude', function () {
     e.shouldInstrument('src/foo/bar.js').should.equal(true)
   })
 
+  it("handles folder '.' in path", function () {
+    const e = exclude()
+    e.shouldInstrument('test/fixtures/basic/.next/dist/pages/async-props.js').should.equal(false)
+  })
+
   it('excludes node_modules folder, even when empty exclude group is provided', function () {
     const e = exclude({
       exclude: []
     })
 
+    e.shouldInstrument('./banana/node_modules/cat.js').should.equal(false)
     e.shouldInstrument('node_modules/some/module/to/cover.js').should.equal(false)
     e.shouldInstrument('__tests__/a-test.js').should.equal(true)
     e.shouldInstrument('src/a.test.js').should.equal(true)
@@ -63,6 +70,7 @@ describe('testExclude', function () {
       exclude: ['!**/node_modules/**']
     })
 
+    e.shouldInstrument('./banana/node_modules/cat.js').should.equal(true)
     e.shouldInstrument('node_modules/some/module/to/cover.js').should.equal(true)
     e.shouldInstrument('__tests__/a-test.js').should.equal(true)
     e.shouldInstrument('src/a.test.js').should.equal(true)
@@ -75,7 +83,8 @@ describe('testExclude', function () {
       'test{,-*}.js',
       '**/*.test.js',
       '**/__tests__/**',
-      '**/node_modules/**'
+      '**/node_modules/**',
+      'node_modules/**'
     ])
   })
 


### PR DESCRIPTION
I ran into a problem instrumenting `next.js`, which has folders like `.next` in its file paths -- it seems like we should allow `.` in our paths in general.