### PR TITLE
chore: Remove coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,3 @@ node_js:
     - 12
     - 10
     - 8
-
-env:
-    global:
-        COVERALLS_PARALLEL: true
-
-after_success: nyc report --reporter=text-lcov | coveralls

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   },
   "homepage": "https://istanbul.js.org/",
   "dependencies": {
-    "coveralls": "^3.0.5",
     "glob": "^7.1.4",
     "minimatch": "^3.0.4"
   },


### PR DESCRIPTION
It's not working but it's also unneeded as this module enforces 100%
coverage.