### PR TITLE
chore: Fix testing to deal with changes to tap/nyc integration

### DIFF
--- a/.taprc
+++ b/.taprc
@@ -1,3 +1,3 @@
 timeout: 360
 bail: true
-100: true
+coverage: false

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -6,6 +6,11 @@ const isWindows = process.platform === 'win32';
 
 module.exports = {
     all: true,
+    checkCoverage: true,
+    lines: 100,
+    functions: 100,
+    branches: 100,
+    statements: 100,
     exclude: [
         ...defaultExclude,
         'is-outside-dir.js',

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   ],
   "scripts": {
     "release": "standard-version",
-    "test": "tap"
+    "test": "nyc tap",
+    "snap": "npm test -- --snapshot"
   },
   "repository": {
     "type": "git",
@@ -33,6 +34,7 @@
     "minimatch": "^3.0.4"
   },
   "devDependencies": {
+    "nyc": "^14.1.1",
     "standard-version": "^7.0.0",
     "tap": "^14.4.2"
   },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "nyc": "^14.1.1",
     "standard-version": "^7.0.0",
-    "tap": "^14.4.2"
+    "tap": "=14.10.2-unbundled"
   },
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
This just disables tap/nyc integration and uses nyc directly as the
integration cannot support conditional excludes.