### PR TITLE
fix: Ignore options that are explicitly set undefined.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,13 +8,18 @@ const { defaults } = require('@istanbuljs/schema');
 const isOutsideDir = require('./is-outside-dir');
 
 class TestExclude {
-    constructor(opts) {
+    constructor(opts = {}) {
         Object.assign(
             this,
             {relativePath: true},
-            defaults.testExclude,
-            opts
+            defaults.testExclude
         );
+
+        for (const [name, value] of Object.entries(opts)) {
+            if (value !== undefined) {
+                this[name] = value;
+            }
+        }
 
         if (typeof this.include === 'string') {
             this.include = [this.include];
@@ -30,7 +35,7 @@ class TestExclude {
             this.extension = false;
         }
 
-        if (this.include.length > 0) {
+        if (this.include && this.include.length > 0) {
             this.include = prepGlobPatterns([].concat(this.include));
         } else {
             this.include = false;

--- a/test/test-exclude.js
+++ b/test/test-exclude.js
@@ -272,3 +272,14 @@ t.test('allows exclude/include rule to be a string', t =>
         yes: ['src/batman/robin/foo.js']
     })
 );
+
+t.test('tolerates undefined exclude/include', t =>
+    testHelper(t, {
+        options: {
+            exclude: undefined,
+            include: undefined
+        },
+        no: ['test.js'],
+        yes: ['index.js']
+    })
+);


### PR DESCRIPTION
This happens in an edge case of nyc use where `new NYC` is called with a
hand-crafted config instead of using the result of config / CLI parsing.