### PR TITLE
feat: Version bump only

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "minimatch": "^3.0.4"
   },
   "devDependencies": {
-    "nyc": "^14.1.1",
+    "nyc": "^15.0.0-beta.3",
     "standard-version": "^7.0.0",
-    "tap": "=14.10.2-unbundled"
+    "tap": "^14.10.5"
   },
   "engines": {
     "node": ">=8"


### PR DESCRIPTION
This commit unpins / updates testing but mainly exists to have a
changelog entry for v6.0.0.