### PR TITLE
fix: Make sure glob and minimatch are case insenitive on win32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules/*
 coverage
 .nyc_output
+.idea

--- a/extension-matcher-posix.js
+++ b/extension-matcher-posix.js
@@ -1,0 +1,5 @@
+'use-strict'
+
+module.exports = (filename) => {
+    return ext => filename.endsWith(ext);
+};

--- a/extension-matcher-win32.js
+++ b/extension-matcher-win32.js
@@ -1,0 +1,5 @@
+'use strict'
+
+module.exports = (filename) => {
+    return ext => filename.toLowerCase().endsWith(ext.toLowerCase());
+};

--- a/extension-matcher.js
+++ b/extension-matcher.js
@@ -1,0 +1,8 @@
+'use strict';
+
+if (process.platform === 'win32') {
+    module.exports = require("./extension-matcher-win32");
+} else {
+    module.exports = require("./extension-matcher-posix");
+}
+

--- a/is-outside-dir-posix.js
+++ b/is-outside-dir-posix.js
@@ -2,6 +2,11 @@
 
 const path = require('path');
 
-module.exports = function(dir, filename) {
-    return /^\.\./.test(path.relative(dir, filename));
+module.exports = {
+    isOutsideDir(dir, filename) {
+        return /^\.\./.test(path.relative(dir, filename));
+    },
+    minimatchOptions: {
+        dot: true
+    }
 };

--- a/is-outside-dir-win32.js
+++ b/is-outside-dir-win32.js
@@ -2,9 +2,14 @@
 
 const path = require('path');
 const minimatch = require('minimatch');
-
-const dot = { dot: true };
-
-module.exports = function(dir, filename) {
-    return !minimatch(path.resolve(dir, filename), path.join(dir, '**'), dot);
+const minimatchOptions = {
+    dot: true,
+    nocase: true // win32 should be case insensitive matches
 };
+
+module.exports = {
+    isOutsideDir(dir, filename) {
+        return !minimatch(path.resolve(dir, filename), path.join(dir, '**'), minimatchOptions)
+    },
+    minimatchOptions
+}

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -14,6 +14,8 @@ module.exports = {
     exclude: [
         ...defaultExclude,
         'is-outside-dir.js',
-        isWindows ? 'is-outside-dir-posix.js' : 'is-outside-dir-win32.js'
+        'extension-matcher.js',
+        isWindows ? 'is-outside-dir-posix.js' : 'is-outside-dir-win32.js',
+        isWindows ? 'extension-matcher-posix.js' : 'extension-matcher-win32.js'
     ]
 };

--- a/tap-snapshots/test-glob.js-TAP.test.js
+++ b/tap-snapshots/test-glob.js-TAP.test.js
@@ -40,6 +40,13 @@ Array [
 ]
 `
 
+exports[`test/glob.js TAP handles case insensitive matches on windows > must match snapshot 1`] = `
+Array [
+  "file1.js",
+  "file2.js",
+]
+`
+
 exports[`test/glob.js TAP should exclude the node_modules folder by default > absolute constructor cwd 1`] = `
 Array [
   "file1.js",

--- a/test/glob.js
+++ b/test/glob.js
@@ -95,3 +95,15 @@ t.test('allows negated include patterns', t =>
         }
     })
 );
+
+if (process.platform === 'win32') {
+    t.test('handles case insensitive matches on windows', t =>
+        testHelper(t, {
+            options: {
+                cwd,
+                extension: extension.toUpperCase(),
+                include: ['file1.js', 'FILE2.js']
+            }
+        })
+    );
+}

--- a/test/test-exclude.js
+++ b/test/test-exclude.js
@@ -67,6 +67,26 @@ if (process.platform === 'win32') {
             no: ['D:\\project\\foo.js']
         })
     );
+
+    t.test('should handle case insensitive drives on win32', t =>
+        testHelper(t, {
+            options: {
+                cwd: 'C:\\project'
+            },
+            yes: ['c:\\project\\foo.js']
+        })
+    );
+
+    t.test('should handle case insensitive paths when on win32', t =>
+        testHelper(t, {
+            options: {
+                exclude: ['foo.js'],
+                include: ['boo.js']
+            },
+            no: ['FOO.js'],
+            yes: ['BOO.js']
+        })
+    );
 }
 
 t.test('can instrument files outside cwd if relativePath=false', t =>


### PR DESCRIPTION
Supplies `nocase` option to minimatch and glob when on win32.
Additionally changes `test-excludes` extension check to be case
insenitive. Adds tests to support this behavior.