### PR TITLE
perf: compile glob patterns to regexp once (Windows-safe retry of #64)  

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,9 @@ const { minimatch } = require('minimatch');
 const { defaults } = require('@istanbuljs/schema');
 const isOutsideDir = require('./is-outside-dir');
 
+const minimatchOptions = { dot: true };
+const patternToRegExp = pattern => minimatch.makeRe(pattern, minimatchOptions);
+
 class TestExclude {
     constructor(opts = {}) {
         Object.assign(
@@ -50,6 +53,13 @@ class TestExclude {
         this.exclude = prepGlobPatterns([].concat(this.exclude));
 
         this.handleNegation();
+        this.compilePatterns();
+    }
+
+    compilePatterns() {
+        this.includeRegexps = this.include === false ? false : this.include.map(patternToRegExp);
+        this.excludeRegexps = this.exclude.map(patternToRegExp);
+        this.excludeNegatedRegexps = this.excludeNegated.map(patternToRegExp);
     }
 
     /* handle the special case of negative globs
@@ -94,11 +104,14 @@ class TestExclude {
             pathToCheck = relFile.replace(/^\.[\\/]/, ''); // remove leading './' or '.\'.
         }
 
-        const dot = { dot: true };
-        const matches = pattern => minimatch(pathToCheck, pattern, dot);
+        // minimatch.makeRe produces regexes that expect forward slashes;
+        // normalize any backslashes so the precompiled regex matches Windows paths.
+        const normalizedPath = pathToCheck.includes('\\') ? pathToCheck.split('\\').join('/') : pathToCheck;
+
+        const matches = re => re.test(normalizedPath);
         return (
-            (!this.include || this.include.some(matches)) &&
-            (!this.exclude.some(matches) || this.excludeNegated.some(matches))
+            (!this.includeRegexps || this.includeRegexps.some(matches)) &&
+            (!this.excludeRegexps.some(matches) || this.excludeNegatedRegexps.some(matches))
         );
     }
 

--- a/test/test-exclude.js
+++ b/test/test-exclude.js
@@ -284,3 +284,18 @@ t.test('tolerates undefined exclude/include', t =>
         yes: ['index.js']
     })
 );
+
+// Patterns are precompiled to forward-slash regexes; verify Windows-style
+// backslash paths still match. shouldInstrument accepts an explicit relFile,
+// which is what we'd see on Windows.
+t.test('matches Windows-style backslash paths against forward-slash globs', t => {
+    const e = new TestExclude({
+        include: ['src/**/*.js'],
+        exclude: ['src/**/*.spec.js']
+    });
+
+    strictEqual(e.shouldInstrument('src\\batman\\robin\\foo.js', 'src\\batman\\robin\\foo.js'), true);
+    strictEqual(e.shouldInstrument('src\\batman\\robin\\foo.spec.js', 'src\\batman\\robin\\foo.spec.js'), false);
+    strictEqual(e.shouldInstrument('src\\node_modules\\cat.js', 'src\\node_modules\\cat.js'), false);
+    t.end();
+});


### PR DESCRIPTION
  Second attempt at #64. Apologies for the radio silence on the original PR.

  `shouldInstrument` re-parses every glob via `minimatch()` on each call, which shows up as a hot path on large test suites. This compiles each pattern to a `RegExp` once in the constructor and reuses it.

  ### Why this didn't work the first time

`minimatch()` normalizes backslashes internally; `minimatch.makeRe()` does not. On Windows, `pathToCheck` arrives with `\` separators and never matches he precompiled forward-slash regex, that's what broke the Windows CI on #64.

  ### Fix
  Normalize `\` → `/` in `pathToCheck` before running the precompiled regex.

  ### Test
Added a test that exercises `shouldInstrument` with backslash paths so the Windows behavior is verified on every CI run, not only on the Windows job.
